### PR TITLE
Fix android build error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,8 @@
 ## 1.1.10
 
 - Resolved android run issue for Inconsistent JVM-target #36
+
+## 1.1.11
+
+- Removed deprecated `PluginRegistry.Registrar` usage in Android plugin to
+  resolve build errors on recent Flutter versions

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add this line to your pubspec.yaml file:
 
 ```
 dependencies:
-  flutter_audio_capture: ^1.1.10
+  flutter_audio_capture: ^1.1.11
 ```
 
 and execute

--- a/android/src/main/kotlin/com/ymd/flutter_audio_capture/FlutterAudioCapturePlugin.kt
+++ b/android/src/main/kotlin/com/ymd/flutter_audio_capture/FlutterAudioCapturePlugin.kt
@@ -8,7 +8,6 @@ import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 
 /** FlutterAudioCapturePlugin */
 public class FlutterAudioCapturePlugin: FlutterPlugin, MethodCallHandler {
@@ -31,11 +30,6 @@ public class FlutterAudioCapturePlugin: FlutterPlugin, MethodCallHandler {
   // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
   // depending on the user's project. onAttachedToEngine or registerWith must both be defined
   // in the same class.
-  companion object {
-    @JvmStatic
-    fun registerWith(registrar: Registrar) {
-    }
-  }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
     when (call.method) {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.10"
+    version: "1.1.11"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_audio_capture
 description: Capture the audio buffer stream through microphone for iOS/Android.
-version: 1.1.10
+version: 1.1.11
 homepage: https://github.com/ysak-y/flutter_audio_capture
 
 environment:


### PR DESCRIPTION
## Summary
- remove deprecated `PluginRegistry.Registrar` API usage
- bump plugin version to 1.1.11
- update example lockfile and docs

## Testing
- `dart test` *(fails: dart not found)*