### PR TITLE
Fix iOS audio session release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,3 +65,12 @@
 
 - Removed deprecated `PluginRegistry.Registrar` usage in Android plugin to
   resolve build errors on recent Flutter versions
+
+## 1.1.12
+
+- Deactivated iOS audio session on stop to restore output audio
+
+## 1.1.13
+
+- Reset iOS audio session to `.ambient` after stopping to fully release the
+  microphone and allow playback

--- a/ios/Classes/AudioCapture.swift
+++ b/ios/Classes/AudioCapture.swift
@@ -90,5 +90,14 @@ public class AudioCapture {
     public func stopSession() {
         audioEngine.inputNode.removeTap(onBus: 0)
         audioEngine.stop()
+        let audioSession = AVAudioSession.sharedInstance()
+        do {
+            try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+            try audioSession.setCategory(.ambient, options: [.mixWithOthers])
+            try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+            print("✅ AudioSession desactivada y liberada correctamente")
+        } catch {
+            print("❌ Error al liberar AudioSession: \(error.localizedDescription)")
+        }
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_audio_capture
 description: Capture the audio buffer stream through microphone for iOS/Android.
-version: 1.1.11
+version: 1.1.13
 homepage: https://github.com/ysak-y/flutter_audio_capture
 
 environment:


### PR DESCRIPTION
## Summary
- release and reset audio session correctly when stopping capture on iOS
- bump version to 1.1.13 and document the fix

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687de816a04c832bb3433fdcdd452a45